### PR TITLE
feat: add support of decoding message between the specified timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cargo install --path crates/rospeek-cli
 
 Then, you can refer to usage of CLI with `rospeek -h`.
 
-#### Show Bag Information and List Topics
+#### 1. Show Bag Information and List Topics
 
 This command shows overviews of a bag file, similar to `rosbag2 info`:
 
@@ -35,7 +35,7 @@ This command shows overviews of a bag file, similar to `rosbag2 info`:
 rospeek info <BAG_FILE>
 ```
 
-#### List Topic Messages
+#### 2. List Topic Messages
 
 This command shows a list of serialized messages:
 
@@ -43,7 +43,7 @@ This command shows a list of serialized messages:
 rospeek show <BAG_FILE> -t <TOPIC_NAME>
 ```
 
-#### Decode Topic Messages and Dump into JSON/CSV
+#### 3. Decode Topic Messages and Dump into JSON/CSV
 
 This command decodes topic messages and dumps them into JSON or CSV format.
 
@@ -59,7 +59,13 @@ For example, the following command dumps `/foo/bar` into `foo.bar.json`:
 rospeek dump <BAG_FILE> -t /foo/bar -f json
 ```
 
-#### Spawn GUI
+You can also dump messages between two timestamps:
+
+```shell
+rospeek dump <BAG_FILE> -t /foo/bar -f json --since 1640995200 --until 1640995260
+```
+
+#### 4. Spawn GUI
 
 This command spawns a GUI application for visualizing bag files:
 

--- a/crates/rospeek-core/src/reader.rs
+++ b/crates/rospeek-core/src/reader.rs
@@ -41,6 +41,9 @@ pub trait BagReader: Send {
 
     /// Reads messages from the bag file since a given timestamp.
     ///
+    /// # Note
+    /// This function reads all messages from the bag file and filters them based on the given timestamp.
+    ///
     /// # Arguments
     /// * `topic_name` - The name of the topic to read messages from.
     /// * `since` - The timestamp to start reading messages from.
@@ -58,6 +61,9 @@ pub trait BagReader: Send {
 
     /// Reads messages from the bag file until a given timestamp.
     ///
+    /// # Note
+    /// This function reads all messages from the bag file and filters them based on the given timestamp.
+    ///
     /// # Arguments
     /// * `topic_name` - The name of the topic to read messages from.
     /// * `until` - The timestamp to stop reading messages at.
@@ -74,6 +80,9 @@ pub trait BagReader: Send {
     }
 
     /// Reads messages from the bag file between two timestamps.
+    ///
+    /// # Note
+    /// This function reads all messages from the bag file and filters them based on the given timestamps.
     ///
     /// # Arguments
     /// * `topic_name` - The name of the topic to read messages from.


### PR DESCRIPTION
## What

This pull request adds support for filtering messages by timestamp when dumping ROS bag topics to JSON or CSV, enhancing both the CLI and core decoding logic. It introduces new command-line options, updates the decoding functions to accept time ranges, and extends the `BagReader` trait with filtering methods.

**CLI Enhancements:**

* Added `--since` and `--until` options to the `dump` command in `rospeek` CLI, allowing users to specify time ranges (in nanoseconds) for messages to export. [[1]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161R49-R54) [[2]](diffhunk://#diff-21dbe9b43bc8097af3ca987eb3ba7519bbde4f5bea6f2a4c8b1bde7c35676161L102-R114)
* Updated the README with numbered usage sections and an example of dumping messages between two timestamps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R46) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R68)

**Core Decoding Logic:**

* Modified `try_decode_json` and `try_decode_csv` in `cdr.rs` to accept optional `since` and `until` parameters, filtering messages accordingly. [[1]](diffhunk://#diff-e8e0536d35dfbb5a063256ff00394c09bad434be0b491e53d880f8c0f843a20cR275-R284) [[2]](diffhunk://#diff-e8e0536d35dfbb5a063256ff00394c09bad434be0b491e53d880f8c0f843a20cL290-R299) [[3]](diffhunk://#diff-e8e0536d35dfbb5a063256ff00394c09bad434be0b491e53d880f8c0f843a20cR317-R328)

**BagReader Trait Extensions:**

* Extended the `BagReader` trait with default methods: `read_messages_since`, `read_messages_until`, and `read_messages_between`, enabling efficient message filtering by timestamp.

**Documentation Improvements:**

* Added and improved doc comments for trait methods and utility functions, clarifying their arguments and return values. [[1]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bR10-R97) [[2]](diffhunk://#diff-6a23460e5088f3498fc83dbf593eda6a5a6aad546b2a1b01744664e8f29da95bR141-R143)